### PR TITLE
watch function should return unwatch

### DIFF
--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -16,8 +16,9 @@
                 function watchDuringDisable() {
                     this.$$watchersBackup = this.$$watchersBackup || [];
                     this.$$watchers = this.$$watchersBackup;
-                    this.constructor.prototype.$watch.apply(this, arguments);
+                    var unwatch = this.constructor.prototype.$watch.apply(this, arguments);
                     this.$$watchers = null;
+                    return unwatch;
                 }
                 function toggleWatchers(scope, enable) {
                     var digest, current, next = scope;

--- a/dist/scripts/angular-viewport-watch.js
+++ b/dist/scripts/angular-viewport-watch.js
@@ -16,8 +16,9 @@
                 function watchDuringDisable() {
                     this.$$watchersBackup = this.$$watchersBackup || [];
                     this.$$watchers = this.$$watchersBackup;
-                    this.constructor.prototype.$watch.apply(this, arguments);
+                    var unwatch = this.constructor.prototype.$watch.apply(this, arguments);
                     this.$$watchers = null;
+                    return unwatch;
                 }
                 function toggleWatchers(scope, enable) {
                     var digest, current, next = scope;


### PR DESCRIPTION
If `$watch` returns nothing then `oneTimeWatchDelegate`, `oneTimeLiteralWatchDelegate` and `constantWatchDelegate` that are trying to call `unwatch` are failing.
Tested with Angular. 1.4.1